### PR TITLE
Update for purple-facebook

### DIFF
--- a/facebook_bitlbee_rename.pl
+++ b/facebook_bitlbee_rename.pl
@@ -27,7 +27,7 @@ sub message_join
   my ($server, $channel, $nick, $address) = @_;
   my ($username, $host) = split /@/, $address;
 
-  if ($host eq 'chat.facebook.com' and $channel =~ m/$bitlbeeChannel/ and $nick =~ m/$username/)
+  if ($host eq 'facebook' and $channel =~ m/$bitlbeeChannel/ and $nick =~ m/$username/)
   {
     $nicksToRename{$nick} = $channel;
     $server->command("whois -- $nick");


### PR DESCRIPTION
Facebook chat no longer supports XMPP. However https://github.com/jgeboski/purple-facebook allows chatting on facebook with irssi bitlbee through libpurple. Buddies from purple-facebook also have gibberish nicks, but the host is 'facebook' instead of 'chat.facebook.com'.
